### PR TITLE
Atualizando .github/CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-caos/@camilamaia/ @camilamaia
-caos/@antoniamaia/ @antoniamaia
+* @cumbucadev/cumbuca-s-core-team @cumbucadev/cumbuca-s-maintainers


### PR DESCRIPTION
Para seguir esse padrão <https://github.com/cumbucadev/generic-template/blob/main/.github/CODEOWNERS>

Closes #68 